### PR TITLE
CI (GitHub Actions): checkout the base repository and all submodules at once

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,8 @@ jobs:
     steps:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - uses: actions/checkout@v2
-        
-      - name: Checkout submodules
-        run: git submodule update --init --recursive
+        with:
+          submodules: 'recursive'
         
       - name: Add msbuild to PATH
         uses: microsoft/setup-msbuild@v1


### PR DESCRIPTION
Hi. This change may not make the workflow run faster, but it can make the workflow file (one line reduced) and the log file (one step reduced) slightly shorter.