### PR TITLE
chore (Git): connect to remote submodule repository with HTTPS

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "Sample/DynamicPatcher"]
 	path = Sample/DynamicPatcher
-	url = git@github.com:Xkein/PatcherSample.git
+	url = https://github.com/Xkein/PatcherSample.git


### PR DESCRIPTION
I've encountered the following errors:

```console
> git submodule update --init
Cloning into '.../Sample/DynamicPatcher'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:Xkein/PatcherSample.git' into submodule path '.../Sample/DynamicPatcher' failed
Failed to clone 'Sample/DynamicPatcher'. Retry scheduled
Cloning into '.../Sample/DynamicPatcher'...
Host key verification failed.
fatal: Could not read from remote repository.

Please make sure you have the correct access rights
and the repository exists.
fatal: clone of 'git@github.com:Xkein/PatcherSample.git' into submodule path '.../Sample/DynamicPatcher' failed
Failed to clone 'Sample/DynamicPatcher' a second time, aborting

```

Using HTTPS URL solved my problem.

Setting up HTTPS is easier than SSH, and AFAIK, changing SSH to HTTPS has no side effects on **this** project, which is not something needs to be treated specially.

Please feel free to discuss this PR or close it directly if you have any concerns or you are using SSH on purpose.
